### PR TITLE
Show traceback when an event handler raises exception

### DIFF
--- a/justpy/justpy.py
+++ b/justpy/justpy.py
@@ -278,7 +278,7 @@ async def handle_event(data_dict, com_type=0):
     except Exception as e:
         # raise Exception(e)
         event_result = None
-        logging.info('%s %s', 'Event result:', '\u001b[47;1m\033[93mAttempting to run event handler:\033[0m')
+        logging.info('%s %s', 'Event result:', '\u001b[47;1m\033[93mAttempting to run event handler:' + str(e) + '\033[0m')
         traceback.print_exc()
 
     # If page is not to be updated, the event_function should return anything but None

--- a/justpy/justpy.py
+++ b/justpy/justpy.py
@@ -18,6 +18,7 @@ from .routing import Route, SetRoute
 from .utilities import run_task, create_delayed_task
 import uvicorn, logging, uuid, sys, os
 from ssl import PROTOCOL_SSLv23
+import traceback
 
 current_module = sys.modules[__name__]
 current_dir = os.path.dirname(current_module.__file__)
@@ -277,7 +278,8 @@ async def handle_event(data_dict, com_type=0):
     except Exception as e:
         # raise Exception(e)
         event_result = None
-        logging.info('%s %s', 'Event result:', '\u001b[47;1m\033[93mAttempting to run event handler:' + str(e) + '\033[0m')
+        logging.info('%s %s', 'Event result:', '\u001b[47;1m\033[93mAttempting to run event handler:\033[0m')
+        traceback.print_exc()
 
     # If page is not to be updated, the event_function should return anything but None
 


### PR DESCRIPTION
Instead of having errors like
```python
INFO:     Event result: Attempting to run event handler:cannot unpack non-iterable Column object
```

we will get errors like
```python
INFO:     Event result: Attempting to run event handler:cannot unpack non-iterable Column object
Traceback (most recent call last):
  File "/Users/pragyagarwal/MW/venv/lib/python3.8/site-packages/justpy/justpy.py", line 276, in handle_event
    event_result = await c.run_event_function(event_data['event_type'], event_data, True)
  File "/Users/pragyagarwal/MW/venv/lib/python3.8/site-packages/justpy/htmlcomponents.py", line 297, in run_event_function
    event_result = event_function(function_data)
  File "/Users/pragyagarwal/MW/mindwiki/view.py", line 328, in clicked
    self._clicked_check_selection()
  File "/Users/pragyagarwal/MW/mindwiki/view.py", line 313, in _clicked_check_selection
    self.sg_selection_attempt.fire((self, selection))
  File "/Users/pragyagarwal/MW/mindwiki/utils/signal.py", line 51, in fire
    sub(message)
  File "/Users/pragyagarwal/MW/mindwiki/view.py", line 423, in _selection_attempt_handler
    self.sg_selection_attempt.fire((self, data[0], data[1]))
  File "/Users/pragyagarwal/MW/mindwiki/utils/signal.py", line 51, in fire
    sub(message)
  File "/Users/pragyagarwal/MW/mindwiki/view.py", line 558, in _selection_attempt
    self._redraw(column.column_index)
  File "/Users/pragyagarwal/MW/mindwiki/view.py", line 546, in _redraw
    last_column_with_selection = max((i for i, column in self._cmp_columns
  File "/Users/pragyagarwal/MW/mindwiki/view.py", line 546, in <genexpr>
    last_column_with_selection = max((i for i, column in self._cmp_columns
TypeError: cannot unpack non-iterable Column object
```