### PR TITLE
Teach add to work with iterables

### DIFF
--- a/justpy/htmlcomponents.py
+++ b/justpy/htmlcomponents.py
@@ -1,11 +1,17 @@
+import asyncio
+import collections
+import copy
+import inspect
+import json
+import re
+import sys
+
 from types import MethodType
 from addict import Dict
-import json, copy, inspect, sys, re
 from html.parser import HTMLParser, tagfind_tolerant, attrfind_tolerant
 from html.entities import name2codepoint
 from html import unescape
 from jinja2 import Template
-import asyncio
 from .tailwind import Tailwind
 import logging
 import httpx
@@ -98,7 +104,11 @@ class WebPage:
 
     def add(self, *args):
         for component in args:
-            self.add_component(component)
+            if isinstance(component, collections.abc.Iterable):
+                for c in component:
+                    self.add_component(c)
+            else:
+                self.add_component(component)
         return self
 
     def __add__(self, other):
@@ -629,7 +639,11 @@ class Div(HTMLBaseComponent):
 
     def add(self, *args):
         for component in args:
-            self.add_component(component)
+            if isinstance(component, collections.abc.Iterable):
+                for c in component:
+                    self.add_component(c)
+            else:
+                self.add_component(component)
         return self
 
     def __add__(self, child):


### PR DESCRIPTION
Hi, @elimintz, thanks for this project!
I used JustPy in a hackathon a couple of weeks ago and I enjoy it very much :)

I'd like to suggest that `add` will support arguments that are iterables.
I find it useful when generating things in a comprehension.

For example:

```python
jp.Table().add(
    jp.Tr().add(
        ...
    ),
    [
        jp.Div(...)
        for user in users
    ],
)
```

What do you think?