### PR TITLE
Setup CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,36 @@
+name: Python package
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest pytest-cov
+        python -m pip install .
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest test --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html

--- a/test/test_importability.py
+++ b/test/test_importability.py
@@ -1,0 +1,8 @@
+"""
+A basic sanity test
+"""
+
+
+def test_importability():
+    import justpy
+    assert justpy


### PR DESCRIPTION
Hi,

I've setup a CI Action, it runs automatically for Python 3.6 to 3.9.
For now, there is only a basic sanity test that checks that the package is importable.

Once this is merged, I'd like to add more tests that will make development easier.

For reference, please see [this](https://github.com/TalAmuyal/justpy/pull/3) example PR.
It edits a file, and you can see the [checks](https://github.com/TalAmuyal/justpy/pull/3/checks) that were executed.