### PR TITLE
QEditor: add `placeholder` to list of properties

### DIFF
--- a/docs/reference/htmlcomponent.md
+++ b/docs/reference/htmlcomponent.md
@@ -405,7 +405,7 @@ Remove references to the object from JustPy internal data structures to allow ga
 Bind a function to an event
 
 `def remove_event(self, event_type)`  
-Remove and event from the element's allowed events
+Remove an event from the element's allowed events
 
 `def has_event_function(self, event_type)`  
 Returns `True` if the element has the specified event

--- a/justpy/quasarcomponents.py
+++ b/justpy/quasarcomponents.py
@@ -1165,7 +1165,7 @@ class QEditor(QInput):
                           'content-class',
                           'definitions', 'fonts', 'toolbar', 'toolbar-color', 'toolbar-text-color',
                           'toolbar-toggle-color',
-                          'toolbar-bg', 'toolbar-outline', 'toolbar-push', 'toolbar-rounded']
+                          'toolbar-bg', 'toolbar-outline', 'toolbar-push', 'toolbar-rounded', 'placeholder']
         self.allowed_events = ['input']
         # self.set_keyword_events(**kwargs)
 


### PR DESCRIPTION
Added `placeholder` to the list of QEditor's properties & fixed typo in doc.