### PR TITLE
Do not HTML escape redirect URL

### DIFF
--- a/justpy/templates/main.html
+++ b/justpy/templates/main.html
@@ -5,7 +5,7 @@
 <script>
 
     {% if page_options.redirect %}
-        location.href = '{{ page_options.redirect }}';
+        location.href = '{{ page_options.redirect|safe }}';
     {%endif %}
 
     var websocket_ready = false;


### PR DESCRIPTION
By default in Jinja values that don't need escaping have to be marked
with the `safe` filter. See
https://jinja.palletsprojects.com/en/3.0.x/templates/#working-with-automatic-escaping

Discovered while debugging ory/hydra#2932