### PR TITLE
Add support for Quasar auto dark mode

### DIFF
--- a/justpy/templates/quasar.html
+++ b/justpy/templates/quasar.html
@@ -85,6 +85,9 @@
         {% if page_options.dark %}
             Quasar.Dark.set(true);
         {% endif %}
+        {% if page_options.dark == "auto" %}
+            Quasar.Dark.set("auto");
+        {% endif %}
     </script>
 
     {% include 'main.html' %}


### PR DESCRIPTION
**This change will allow for Quasar auto-detection of dark mode based on client browser**

Currently it is possible to set `dark=True` for a `QuasarPage` which will enable dark mode. Moreover one can set `dark=False` to disable dark mode (default). With this small change in `quasar.html` one can also set `dark="auto"` to use the auto-detection for dark mode of Quasar (see [Quasar dark mode documentation](https://quasar.dev/style/dark-mode)).

Minimal working example for Quasar auto-detection of dark mode:
```python
import justpy as jp

def my_click(self, msg):
    self.text = 'I was clicked!'

def hello_world():
    wp = jp.QuasarPage(dark="auto")
    d = jp.Div(text='Hello world!')
    d.on('click', my_click)
    wp.add(d)
    return wp

jp.justpy(hello_world)
```