### PR TITLE
fixes #384

### DIFF
--- a/justpy/templates/js/aggrid.js
+++ b/justpy/templates/js/aggrid.js
@@ -11,7 +11,7 @@ Vue.component('grid', {
                 for (const element of def) {
                     this.evaluate_formatters(element);
                 }
-            } else if (typeof def == "object") {
+            } else if (typeof def == "object" && def !== null) {
                 for (const [key, value] of Object.entries(def)) {
                     if (key.toLowerCase().includes('formatter')) {
                         eval('def[key] = ' + def[key]);


### PR DESCRIPTION
Under certain circumstances - which I can't manage to reproduce in a minimum example - `def` can be `null` which is of type "object" but causes an error one line below. This pull request handles this case explicitly.